### PR TITLE
MO: Displaying correct estimation Date of Delevery in FO account order detail

### DIFF
--- a/dateofdelivery.php
+++ b/dateofdelivery.php
@@ -413,7 +413,9 @@ class DateOfDelivery extends Module
 		if (empty($carrier_rule))
 			return false;
 
-		if ($date != null && Validate::isDate($date) && strtotime($date) > time())
+		if($date != null && Validate::isDate($date) && $order)
+			$date_now = strtotime($date);
+		elseif ($date != null && Validate::isDate($date) && strtotime($date) > time())
 			$date_now = strtotime($date);
 		else
 			$date_now = time(); // Date on timestamp format


### PR DESCRIPTION
| Questions | Answers |
| --- | --- |
| Branch? | Module dateofdelivery. |
| Description? | Date was estimated from current date , instead of order date creation, so the inforamtion was wrong. |
| Type? | bug fix |
| Category? | MO |
| BC breaks? | no |
| Deprecations? | no |
| Fixed ticket? | - |
| How to test? | Berfore the patch, install and configure this module, make an order and after go to your account, see the detail of an order. few day afeter, go again on the order detail , and the estimation date has changed. After the patch, the estimation date is now based  on order date |

Date was estimated from current date , instead of order date creation, so the inforamtion was wrong.
